### PR TITLE
Update contract.js

### DIFF
--- a/contract.js
+++ b/contract.js
@@ -70,10 +70,10 @@ var contract = (function(module) {
 
         var argTopics = logABI.anonymous ? copy.topics : copy.topics.slice(1);
         var indexedData = "0x" + argTopics.map(function (topics) { return topics.slice(2); }).join("");
-        var indexedParams = ethJSABI.decodeEvent(partialABI(logABI, true), indexedData);
+        var indexedParams = ethJSABI.decodeEvent(partialABI(logABI, true), indexedData, argTopics);
 
         var notIndexedData = copy.data;
-        var notIndexedParams = ethJSABI.decodeEvent(partialABI(logABI, false), notIndexedData);
+        var notIndexedParams = ethJSABI.decodeEvent(partialABI(logABI, false), notIndexedData, argTopics);
 
         copy.event = logABI.name;
 


### PR DESCRIPTION
Add argTopics parameter to the decodeEvent call.
Not adding this was causing the topics not to be passed to the function, resulting in a JavaScript error: "cannot get property '0' of undefined"